### PR TITLE
Changed permament redirect to temporary redirect

### DIFF
--- a/custom-login/main.go
+++ b/custom-login/main.go
@@ -109,7 +109,7 @@ func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		session.Save(r, w)
 	}
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 func ProfileHandler(w http.ResponseWriter, r *http.Request) {
@@ -136,7 +136,7 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	session.Save(r, w)
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 func exchangeCode(code string, r *http.Request) Exchange {

--- a/okta-hosted-login/main.go
+++ b/okta-hosted-login/main.go
@@ -64,7 +64,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	redirectPath = os.Getenv("ISSUER") + "/v1/authorize?" + q.Encode()
 
-	http.Redirect(w, r, redirectPath, http.StatusMovedPermanently)
+	http.Redirect(w, r, redirectPath, http.StatusTemporaryRedirect)
 }
 
 func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +99,7 @@ func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		session.Save(r, w)
 	}
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 func ProfileHandler(w http.ResponseWriter, r *http.Request) {
@@ -126,7 +126,7 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	session.Save(r, w)
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }
 
 func exchangeCode(code string, r *http.Request) Exchange {


### PR DESCRIPTION
If the redirect sends a permanent redirect status code (StatusMovedPermanently--308), clients are
allowed to cache the redirect and skip the original request on subsequent requests. In the case of this code, skipping nonce generation the second time someone logs in within the same session. Likewise with logout, the session clearing will never happen the second time around.

This change is a fix for that behavior, basically telling the client this is a temp redirect and clients should always replay the request.