### PR TITLE
Change redirects status code from 301 to 302

### DIFF
--- a/custom-login/main.go
+++ b/custom-login/main.go
@@ -110,7 +110,7 @@ func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		session.Save(r, w)
 	}
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func ProfileHandler(w http.ResponseWriter, r *http.Request) {
@@ -137,7 +137,7 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	session.Save(r, w)
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func exchangeCode(code string, r *http.Request) Exchange {

--- a/okta-hosted-login/main.go
+++ b/okta-hosted-login/main.go
@@ -65,7 +65,7 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	redirectPath = os.Getenv("ISSUER") + "/v1/authorize?" + q.Encode()
 
-	http.Redirect(w, r, redirectPath, http.StatusMovedPermanently)
+	http.Redirect(w, r, redirectPath, http.StatusFound)
 }
 
 func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +100,7 @@ func AuthCodeCallbackHandler(w http.ResponseWriter, r *http.Request) {
 		session.Save(r, w)
 	}
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func ProfileHandler(w http.ResponseWriter, r *http.Request) {
@@ -127,7 +127,7 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 
 	session.Save(r, w)
 
-	http.Redirect(w, r, "/", http.StatusMovedPermanently)
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 func exchangeCode(code string, r *http.Request) Exchange {


### PR DESCRIPTION
When testing this out, if a user gets the ISSUER wrong, browsers will cache the 301 and the new redirect URL will not be used.

Browsers cache 301 redirects and the only way to clear them is to restart the browser. This is done because a Permanent redirect means, the redirect URL should never change.

For development and testing, changing this to a 302 is desirable. We're not trying to optimize for speed, just trying to make it work.

Replaces #13 
Replaces #10 