### PR TITLE
Fixed OIDC auth issue

### DIFF
--- a/okta-hosted-login/main.go
+++ b/okta-hosted-login/main.go
@@ -144,7 +144,7 @@ func exchangeCode(code string, r *http.Request) Exchange {
 
 	q := r.URL.Query()
 	q.Add("grant_type", "authorization_code")
-	q.Add("code", code)
+	q.Set("code", code)
 	q.Add("redirect_uri", "http://localhost:8080/authorization-code/callback")
 
 	url := os.Getenv("ISSUER") + "/v1/token?" + q.Encode()

--- a/okta-hosted-login/templates/home.gohtml
+++ b/okta-hosted-login/templates/home.gohtml
@@ -4,7 +4,7 @@
 <div id="content" class="ui text container">
   <h2>Okta Hosted Login + Golang Example</h2>
 
-{{if .IsAuthenticated}}
+  {{if .IsAuthenticated}}
   <div>
     <p>Welcome back, <span>{{.Profile.name}}</span>!</p>
     <p>You have successfully authenticated against your Okta org, and have been redirected back to this application.</p>
@@ -15,10 +15,12 @@
   <div>
     <p>Hello!</p>
     <p>If you're viewing this page then you have successfully configured and started this example server.</p>
-    <p>This example shows you how to to add the <a href="https://developer.okta
-            .com/authentication-guide/implementing-authentication/auth-code.html">Authorization Code Flow</a> to your
+    <p>This example shows you how to to add the <a
+        href="https://developer.okta.com/authentication-guide/implementing-authentication/auth-code.html">Authorization
+        Code Flow</a> to your
       Golang application.</p>
-    <p>When you click the login button below, you will be redirected to the login page on your Okta org.  After you authenticate, you will be returned to this application.</p>
+    <p>When you click the login button below, you will be redirected to the login page on your Okta org. After you
+      authenticate, you will be returned to this application.</p>
   </div>
 
   <form method="get" action="login">

--- a/okta-hosted-login/utils/parseEnv.go
+++ b/okta-hosted-login/utils/parseEnv.go
@@ -47,6 +47,12 @@ func setEnvVariable(env string, current string) {
 
 	for lookInFile.Scan() {
 		parts := strings.Split(lookInFile.Text(), "=")
+
+		// safety for empty lines or lines with multiple '='
+		if len(parts) != 2 {
+			continue
+		}
+
 		key, value := parts[0], parts[1]
 		if key == env {
 			os.Setenv(key, value)


### PR DESCRIPTION
Fixed 2 issues:
- Homepage template had an unnecessary newline, along with spacing that botched the URL to the okta auth code flow site
- "func exchangeCode" has a line that does q.Add("code", ..), this creates a duplicate entry to the query URL for code, making a slice of 2 of the same auth code, q.Set("code", ..) fixes this.

Pulling this into master since there is no 'develop' branch as stated in the contrib docs, please update the contrib docs and clarify the branch you want to be used as develop.