### PR TITLE
okta-hosted-login: Fix documentation link

### DIFF
--- a/okta-hosted-login/templates/profile.gohtml
+++ b/okta-hosted-login/templates/profile.gohtml
@@ -4,7 +4,7 @@
   <div>
     <h2>My Profile</h2>
     <p>Hello, <span>{{ .Profile.name }}</span>. Below is the information that was read from the userinfo endpoint with
-      your <a href="https://developer.okta.com/docs/api/resources/oidc.html#get-user-information" target="_blank">Access Token</a> .
+      your <a href="https://developer.okta.com/docs/api/resources/oidc.html#userinfo" target="_blank">Access Token</a> .
     </p>
 
   </div>


### PR DESCRIPTION
Fixes the link for the user info API